### PR TITLE
Option to build as runnable library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,11 @@ bin/
 obj/
 publish/
 
+# Unwanted Microsoft solution config file - csproj is enough
+*.sln
+
 # VS Code
 .vscode/
 
-# Version artifacts
+# Local Version override - shouldn't get into the repo, but can be used for local override
 version.local.txt

--- a/Program.cs
+++ b/Program.cs
@@ -1,51 +1,57 @@
-﻿using System.Drawing.Printing;
-using System.Runtime.InteropServices;
-
-if (args.Length == 1 && (args[0] == "-h" || args[0] == "--help" || args[0] == "/h" || args[0] == "/?"))
+﻿public class Program
 {
-    ShowHelp();
-    return 0;
-}
+    static readonly HashSet<string> ValidHelpArgs = new HashSet<string> { "-h", "--help", "/h", "/?" };
 
-if (args.Length != 2)
-{
-    Console.WriteLine("Error: Incorrect number of arguments");
-    ShowHelp();
-    return 1;
-}
-
-string printerName = args[0];
-string filePath = args[1];
-
-try
-{
-    if (!File.Exists(filePath))
+    static int Main(string[] args)
     {
-        Console.WriteLine($"Error: File not found - {filePath}");
-        return 2;
+        if (args.Length == 1 && ValidHelpArgs.Contains(args[0]))
+        {
+            ShowHelp();
+            return 0;
+        }
+
+        if (args.Length != 2)
+        {
+            Console.WriteLine("Error: Incorrect number of arguments");
+            ShowHelp();
+            return 1;
+        }
+
+        string printerName = args[0];
+        string filePath = args[1];
+
+        try
+        {
+            if (!File.Exists(filePath))
+            {
+                Console.WriteLine($"Error: File not found - {filePath}");
+                return 2;
+            }
+
+            byte[] fileBytes = File.ReadAllBytes(filePath);
+            RawPrinter.SendBytesToPrinter(printerName, fileBytes);
+            Console.WriteLine($"Document sent to printer: {printerName}");
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Printing error: {ex.Message}");
+            return 3;
+        }
     }
 
-    byte[] fileBytes = File.ReadAllBytes(filePath);
-    RawPrinter.SendBytesToPrinter(printerName, fileBytes);
-    Console.WriteLine($"Document sent to printer: {printerName}");
-    return 0;
-}
-catch (Exception ex)
-{
-    Console.WriteLine($"Printing error: {ex.Message}");
-    return 3;
-}
-
-static void ShowHelp()
-{
-    Console.WriteLine("RawPrint - Direct RAW printing utility for Windows.");
-    Console.WriteLine("Usage:");
-    Console.WriteLine("\tRawPrint <printer-name> <file-path>");
-    Console.WriteLine("");
-    Console.WriteLine("Example:");
-    Console.WriteLine("  RawPrint \"My Printer\" C:\\Files\\document.prn");
-    Console.WriteLine("");
-    Console.WriteLine("Notes:");
-    Console.WriteLine("  - Printer name must match exactly with installed printer. Use `Get-Printer` PowerShell cmdlet to get printer names.");
-    Console.WriteLine("  - File will be sent to printer without modification (RAW).");
+    static void ShowHelp()
+    {
+        Console.WriteLine($"RawPrint v{typeof(Program).Assembly.GetName().Version} - direct RAW printing utility for Windows.");
+        Console.WriteLine("");
+        Console.WriteLine("Usage:");
+        Console.WriteLine("\tRawPrint <printer-name> <file-path>");
+        Console.WriteLine("");
+        Console.WriteLine("Example:");
+        Console.WriteLine("\tRawPrint \"My Printer\" C:\\Files\\document.prn");
+        Console.WriteLine("");
+        Console.WriteLine("Notes:");
+        Console.WriteLine("  - Printer name must match exactly with installed printer. Use `Get-Printer` PowerShell cmdlet to get printer names.");
+        Console.WriteLine("  - File will be sent to printer without modification (RAW).");
+    }
 }

--- a/README.md
+++ b/README.md
@@ -17,20 +17,20 @@ Uses the Windows `winspool.drv` API to send RAW byte streams directly to printer
 RawPrint <printer-name> <file-path>
 ```
 
-### Arguments
+Arguments:
 
 | Argument     | Description                            |
 |--------------|----------------------------------------|
 | printer-name | Exact name of installed printer        |
 | file-path    | Path to file containing raw print data |
 
-### Example
+Example:
 
 ```cmd
 RawPrint "HP OfficeJet Pro" C:\printjobs\document.prn
 ```
 
-### Return Codes
+Return Codes:
 
 | Code | Meaning           |
 |------|-------------------|
@@ -49,7 +49,7 @@ Inkjet printers are particularly susceptible to ink drying in the print head noz
 
 While printing regular images can help, it consumes significant ink and provides limited diagnostic information about nozzle health.
 
-Epson printers offer a specialized solution: The **Nozzle Check command** - a binary instruction that efficiently:
+Epson printers offer a specialized solution - the **Nozzle Check command** - a binary instruction that efficiently:
 
 1. Uses minimal ink
 2. Provides clear visual diagnostics
@@ -57,7 +57,7 @@ Epson printers offer a specialized solution: The **Nozzle Check command** - a bi
 
 However, sending these manufacturer-specific RAW commands automatically (regularly) isn't implemented.
 
-## Sample usage: Automated Nozzle Check Workflow
+## Sample usage - Automated Nozzle Check Workflow
 
 Here's how to implement scheduled nozzle checks using RawPrint:
 

--- a/RawPrint.csproj
+++ b/RawPrint.csproj
@@ -4,6 +4,7 @@
     <AssemblyName>RawPrint</AssemblyName>
 
     <!-- Versioning System -->
+    <!-- base version as MAJOR.MINOR in file `version.txt`. GitHub adds its build number as PATCH. Locally built-version use `.0` as PATCH. -->
     <VersionBase Condition="'$(VersionBase)' == ''">$([System.IO.File]::ReadAllText('version.txt').Trim())</VersionBase>
     <VersionPatch Condition="'$(VersionPatch)' == ''">0</VersionPatch>
     <VersionSuffix Condition="'$(VersionSuffix)' == ''"></VersionSuffix>
@@ -16,19 +17,22 @@
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <InvariantGlobalization>true</InvariantGlobalization>
     <SelfContained>false</SelfContained>
-    <!-- Runnable library publish variant - very small -->
-    <!--
-    <OutputType>library</OutputType>
-    <PublishSingleFile>false</PublishSingleFile>
-    <EnableDynamicLoading>true</EnableDynamicLoading>
-    -->
-    <!-- Executable publish variant - larger, but still ok -->
+    <!-- Default publish - as a single executable non-self-contained file -->
     <OutputType>exe</OutputType>
     <PublishSingleFile>true</PublishSingleFile>
 
     <!-- Language features -->
     <ImplicitUsings>true</ImplicitUsings>
     <Nullable>enable</Nullable>
+  </PropertyGroup>
 
+  <!-- RUNNABLE LIBRARY publish configuration [optional]
+  Conditional for when OutputType is `library` to build a library (smaller size) which can be run via `dotnet RawPrint.dll`.
+  To trigger this publish mode use:
+    `dotnet publish -c Release -p:OutputType=library`
+  -->
+  <PropertyGroup Condition="'$(OutputType)' == 'library'">
+    <PublishSingleFile>false</PublishSingleFile>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
   </PropertyGroup>
 </Project>

--- a/RawPrint.csproj
+++ b/RawPrint.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Assembly info -->
     <AssemblyName>RawPrint</AssemblyName>
-    <InvariantGlobalization>true</InvariantGlobalization>
 
     <!-- Versioning System -->
     <VersionBase Condition="'$(VersionBase)' == ''">$([System.IO.File]::ReadAllText('version.txt').Trim())</VersionBase>
@@ -13,14 +12,22 @@
     <AssemblyVersion>$(VersionBase).0.0</AssemblyVersion>
 
     <!-- Publish configuration -->
-    <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
-    <PublishSingleFile>true</PublishSingleFile>
+    <InvariantGlobalization>true</InvariantGlobalization>
     <SelfContained>false</SelfContained>
+    <!-- Runnable library publish variant - very small -->
+    <!--
+    <OutputType>library</OutputType>
+    <PublishSingleFile>false</PublishSingleFile>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+    -->
+    <!-- Executable publish variant - larger, but still ok -->
+    <OutputType>exe</OutputType>
+    <PublishSingleFile>true</PublishSingleFile>
 
     <!-- Language features -->
-    <ImplicitUsings>enable</ImplicitUsings>
+    <ImplicitUsings>true</ImplicitUsings>
     <Nullable>enable</Nullable>
 
   </PropertyGroup>

--- a/RawPrinter.cs
+++ b/RawPrinter.cs
@@ -1,5 +1,5 @@
-using System.Drawing.Printing;
 using System.Runtime.InteropServices;
+
 
 public static class RawPrinter
 {


### PR DESCRIPTION
Runnable library is significantly smaller in size (exe 160KB, library - 8KB), but user needs to use `dotnet RawPrint.dll` command to run it.

To trigger the build as runnable library use `dotnet publish -c Release -p:OutputType=library` command.